### PR TITLE
Improve compatibility on PlatformIO

### DIFF
--- a/src/MovingAverage.h
+++ b/src/MovingAverage.h
@@ -11,11 +11,9 @@ template <class TypeOfArray>
 class MovingAverage {
  private:
   size_t _array_size;
-  TypeOfArray *_array;
-
   size_t _current_index;
+  TypeOfArray *_array;
   TypeOfArray _average_sum;
-
   TypeOfArray _initial_value;
 
   void _nextIndex() {


### PR DESCRIPTION
GCC is more strict on some other platforms other then Arduino.
On PlatformIO, it will complain and throw error if the order of the variable declared does not match the order of the initialization.
So the order of declaration is changed to match the order on the initialization.